### PR TITLE
Optimize `GetRays`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies.rust-embree]
-path = "/home/mujin/workdesk/rust-embree"
+path = "../rust-embree"
 
 [dependencies]
 eframe = "0.28.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ image = "0.25.2"
 nalgebra = "0.33.0"
 raylib = "5.0.1"
 russimp = "3.2.0"
+itertools = "0.12.1"
 
 
 [dev-dependencies]

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -75,16 +75,12 @@ impl Camera {
         // rotate ray directions about world y axis to look towards the origin
         let rayOrigins = rayDirections.zeros().add_vector(Vector3::<f32>::new(0.0, 0.0, 10.0));
 
-        let mut vec: Vec<(f32, f32, f32, f32, f32, f32)> = Vec::with_capacity(rayDirections.len());
-
-        for (origin, direction) in rayOrigins.iter().zip(rayDirections.iter()) {
-            vec.push((
+        rayOrigins.iter().zip(rayDirections.iter()).map(|(origin, direction)| {
+            (
                 origin[0], origin[1], origin[2],
                 direction[0], direction[1], direction[2]
-            ));
-        }
-
-        vec
+            )
+        }).collect()
     }
 
     pub fn resize(&mut self, imageWidth: f32, imageHeight: f32) {


### PR DESCRIPTION
Mostly just removing intermediate results from the computation so only one `Vec` is allocated at the end.

I also made the path to embree relative.

![pdf](https://github.com/user-attachments/assets/c557d859-63bb-4c64-a22e-354140ed434f)
 
Blue is from the most recent version, red is from a commit before (so it still has the `collect` optimization).